### PR TITLE
Fix unwrap() causing panic at exit on Windows.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,10 @@ fn get_thok_events(should_tick: bool) -> mpsc::Receiver<ThokEvent> {
     if should_tick {
         let tick_x = tx.clone();
         thread::spawn(move || loop {
-            tick_x.send(ThokEvent::Tick).unwrap();
+            if tick_x.send(ThokEvent::Tick).is_err() {
+                break;
+            }
+
             thread::sleep(Duration::from_millis(100))
         });
     }
@@ -243,10 +246,14 @@ fn get_thok_events(should_tick: bool) -> mpsc::Receiver<ThokEvent> {
     thread::spawn(move || loop {
         match event::read().unwrap() {
             Event::Key(key) => {
-                tx.send(ThokEvent::Key(key)).unwrap();
+                if tx.send(ThokEvent::Key(key)).is_err() {
+                    break;
+                }
             }
             Event::Resize(_, _) => {
-                tx.send(ThokEvent::Resize).unwrap();
+                if tx.send(ThokEvent::Resize).is_err() {
+                    break;
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What:** Fix process always panicking on exit on Windows.

<!-- Why are these changes necessary? -->

**Why:** This bug isn't critical as it mainly occurs when the process is already exiting, but I think it would be better for the process to exit nominally instead of panicking so as not to confuse the user.

<!-- How were these changes implemented? -->

**How**: The problem is caused by resize event arriving when the main thread and, therefore, the receiver end of the channel is already dead. All I did was replacing `unwrap` with a conditional break. Even though the problem presents itself only with the resize event at the moment, I figured it would be better and more consistent to change all three cases to a conditional break. Another option would be to return the join handles main and join them in the end, but since the code inside both threads is just an infinite cycle, breaking seems like a more straightforward and cleaner choice.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
- [ ] Tests added
- [x] No linting errors / broken tests
- [x] Merge ready
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
